### PR TITLE
Quick Fix for #7 VERSION file not included in PyPi package (wheels)

### DIFF
--- a/semrush/__init__.py
+++ b/semrush/__init__.py
@@ -1,5 +1,5 @@
-import os
-import click
+#import os
+#import click
 
 
-__version__ = open(os.path.join(".", "VERSION")).read().strip()
+#__version__ = open(os.path.join(".", "VERSION")).read().strip() # TODO figure out how to include version at build time because pypi wheels do not include non-code files like VERSION


### PR DESCRIPTION
* [__init__.py] Comment out all lines as a quick fix for the VERSION file and its version number not being available at runtime when the package is installed via pip from pypi. This happens because files outside of the semrush dir aren't included in the wheel when uploaded to PyPi; pip prefers to install from wheels when its available, so it's important that we figure out a way to make that work.


This PR will comment out all the lines in __init__.py so that the CLI can actually run. As of right now, when packaging this tool, two outputs are created and uploaded to PyPi: wheels and a `.tar`. The `.tar` contains all the files that we want, including the `VERSION` file, but pip prefers to use wheels when available. 

This is only a patch so that the CLI can work. There is more work to be done here.