### PR TITLE
Revert "Quick Fix for #7 VERSION file not included in PyPi package (wheels)"

### DIFF
--- a/semrush/__init__.py
+++ b/semrush/__init__.py
@@ -1,5 +1,5 @@
-#import os
-#import click
+import os
+import click
 
 
-#__version__ = open(os.path.join(".", "VERSION")).read().strip() # TODO figure out how to include version at build time because pypi wheels do not include non-code files like VERSION
+__version__ = open(os.path.join(".", "VERSION")).read().strip()


### PR DESCRIPTION
Reverts gshel/semrush-cli#9

Version didn't bump properly because of PR title