### PR TITLE
Remove wheel from build

### DIFF
--- a/.github/workflows/push-to-master.yml
+++ b/.github/workflows/push-to-master.yml
@@ -52,10 +52,10 @@ jobs:
         if: ${{ steps.increment.outputs.TYPE }}
         run: |
           python -m pip install build --user
-      - name: Build a binary wheel and a source tarball
+      - name: Build a source tarball
         if: ${{ steps.increment.outputs.TYPE }}
         run: |
-          python -m build --sdist --wheel --outdir dist/ .
+          python -m build --sdist --outdir dist/ .
       - name: Publish distribution 📦 to Test PyPI
         if: ${{ steps.increment.outputs.TYPE }}
         uses: pypa/gh-action-pypi-publish@master


### PR DESCRIPTION
Uploading both a binary wheel and a source tarball to pypi is hard, so we'll just upload only the source tarball as it works as we expect.

This should actually resolve the VERSION file issue we were facing, as well as the problem with including the additional directories in the package.