### PR TITLE
Fix issue 2 missing version file

### DIFF
--- a/.github/workflows/push-to-master.yml
+++ b/.github/workflows/push-to-master.yml
@@ -52,10 +52,10 @@ jobs:
         if: ${{ steps.increment.outputs.TYPE }}
         run: |
           python -m pip install build --user
-      - name: Build a source tarball
+      - name: Build a binary wheel and a source tarball
         if: ${{ steps.increment.outputs.TYPE }}
         run: |
-          python -m build --sdist --outdir dist/ .
+          python -m build --sdist --wheel --outdir dist/ .
       - name: Publish distribution 📦 to Test PyPI
         if: ${{ steps.increment.outputs.TYPE }}
         uses: pypa/gh-action-pypi-publish@master

--- a/semrush/__init__.py
+++ b/semrush/__init__.py
@@ -1,4 +1,5 @@
-#import os
-#import click
+import os
+import click
 
-#__version__ = open(os.path.join(".", "VERSION")).read().strip() # TODO figure out how to include version at build time because pypi wheels do not include non-code files like VERSION
+click.echo(os.getcwd())
+__version__ = open(os.path.join("..", "VERSION")).read().strip()

--- a/semrush/__init__.py
+++ b/semrush/__init__.py
@@ -1,5 +1,5 @@
 import os
 import click
 
-click.echo(os.getcwd())
+
 __version__ = open(os.path.join("..", "VERSION")).read().strip()

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
         "Programming Language :: Python :: 3.8",
     ],
     keywords="semrush, command-line, command-line interface",
+    package_data={'semrush':['../VERSION']},
     package_dir={"": "."},
     packages=find_packages(where="."),
     include_package_data=True,


### PR DESCRIPTION
This PR *actually* fixes the packaging issues which was presenting itself as a missing VERSION file.

When building the dist files for a package, there are two types: source tarball and binary wheels.

When given the choice, pip will use the binary wheel to install because it's a lot faster.

In the past, I've only used source tarballs, although I hadn't realized why: binary wheels do not include files which your code may rely on, unless you do some extra things (which I've done and verified in this PR). 

relevant links:

- https://packaging.python.org/guides/distributing-packages-using-setuptools/#package-data
- https://stackoverflow.com/questions/24347450/how-do-you-add-additional-files-to-a-wheel